### PR TITLE
Add JWT authentication support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,33 @@
         </maven.checkstyle.plugin.configLocation>
         <lombok.mapstruct.binding.version>0.2.0</lombok.mapstruct.binding.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <liquibase.version>4.29.2</liquibase.version>
+        <lombok.version>1.18.28</lombok.version>
+        <jjwt.version>0.12.6</jjwt.version>
+        <mysql.version>8.4.0</mysql.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
@@ -97,7 +121,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.4.0</version>
+            <version>${mysql.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/mate/academy/onlinebookstore/config/SecurityConfig.java
+++ b/src/main/java/mate/academy/onlinebookstore/config/SecurityConfig.java
@@ -1,10 +1,11 @@
 package mate.academy.onlinebookstore.config;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 import lombok.RequiredArgsConstructor;
+import mate.academy.onlinebookstore.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -12,17 +13,26 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableMethodSecurity
 public class SecurityConfig {
     private final UserDetailsService userDetailsService;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
 
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     @Bean
@@ -32,6 +42,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/auth/login",
                                 "/auth/registration",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
@@ -41,8 +52,10 @@ public class SecurityConfig {
                         .anyRequest()
                         .authenticated()
                 )
-                .httpBasic(withDefaults())
                 .userDetailsService(userDetailsService)
+                .addFilterBefore(
+                        jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/src/main/java/mate/academy/onlinebookstore/controller/AuthenticationController.java
+++ b/src/main/java/mate/academy/onlinebookstore/controller/AuthenticationController.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mate.academy.onlinebookstore.dto.UserDto;
+import mate.academy.onlinebookstore.dto.UserLoginRequestDto;
+import mate.academy.onlinebookstore.dto.UserLoginResponseDto;
 import mate.academy.onlinebookstore.dto.UserRegistrationRequestDto;
 import mate.academy.onlinebookstore.exception.RegistrationException;
+import mate.academy.onlinebookstore.service.AuthenticationService;
 import mate.academy.onlinebookstore.service.UserService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,11 +22,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthenticationController {
     private final UserService userService;
+    private final AuthenticationService authenticationService;
 
     @Operation(summary = "Register a new user", description = "Creates a new user account.")
-    @PostMapping("/registr")
-    public UserDto register(@Valid @RequestBody UserRegistrationRequestDto request)
+    @PostMapping("/registration")
+    public UserDto registration(@Valid @RequestBody UserRegistrationRequestDto request)
             throws RegistrationException {
         return userService.register(request);
+    }
+
+    @Operation(summary = "Login user", description = "Authenticates user and returns JWT token.")
+    @PostMapping("/login")
+    public UserLoginResponseDto login(@Valid @RequestBody UserLoginRequestDto request) {
+        return authenticationService.authenticate(request);
     }
 }

--- a/src/main/java/mate/academy/onlinebookstore/dto/UserLoginRequestDto.java
+++ b/src/main/java/mate/academy/onlinebookstore/dto/UserLoginRequestDto.java
@@ -1,0 +1,13 @@
+package mate.academy.onlinebookstore.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserLoginRequestDto(
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        String password
+) {
+}

--- a/src/main/java/mate/academy/onlinebookstore/dto/UserLoginResponseDto.java
+++ b/src/main/java/mate/academy/onlinebookstore/dto/UserLoginResponseDto.java
@@ -1,0 +1,6 @@
+package mate.academy.onlinebookstore.dto;
+
+public record UserLoginResponseDto(
+        String token
+) {
+}

--- a/src/main/java/mate/academy/onlinebookstore/security/JwtAuthenticationFilter.java
+++ b/src/main/java/mate/academy/onlinebookstore/security/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-        String authHeader = request.getHeader("Authorization");
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
             filterChain.doFilter(request, response);

--- a/src/main/java/mate/academy/onlinebookstore/security/JwtAuthenticationFilter.java
+++ b/src/main/java/mate/academy/onlinebookstore/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package mate.academy.onlinebookstore.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(BEARER_PREFIX.length());
+
+        if (jwtUtil.isValidToken(token)
+                && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String username = jwtUtil.getUsername(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+
+            authentication.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request)
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/mate/academy/onlinebookstore/security/JwtUtil.java
+++ b/src/main/java/mate/academy/onlinebookstore/security/JwtUtil.java
@@ -1,0 +1,49 @@
+package mate.academy.onlinebookstore.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+    private final SecretKey secret;
+
+    public JwtUtil(@Value("${jwt.secret}") String secretString) {
+        this.secret = Keys.hmacShaKeyFor(secretString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24))
+                .signWith(secret)
+                .compact();
+    }
+
+    public boolean isValidToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secret)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String getUsername(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secret)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getSubject();
+    }
+}

--- a/src/main/java/mate/academy/onlinebookstore/service/AuthenticationService.java
+++ b/src/main/java/mate/academy/onlinebookstore/service/AuthenticationService.java
@@ -1,0 +1,27 @@
+package mate.academy.onlinebookstore.service;
+
+import lombok.RequiredArgsConstructor;
+import mate.academy.onlinebookstore.dto.UserLoginRequestDto;
+import mate.academy.onlinebookstore.dto.UserLoginResponseDto;
+import mate.academy.onlinebookstore.security.JwtUtil;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationService {
+    private final JwtUtil jwtUtil;
+    private final AuthenticationManager authenticationManager;
+
+    public UserLoginResponseDto authenticate(UserLoginRequestDto request) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        request.email(),
+                        request.password()
+                )
+        );
+        String token = jwtUtil.generateToken(request.email());
+        return new UserLoginResponseDto(token);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,4 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
 server.servlet.context-path=/api
+jwt.secret=BookStoreJwtSecretKeyForMateAcademyProject2026VeryLongKey123

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,4 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+jwt.secret=BookStoreJwtSecretKeyForMateAcademyProject2026VeryLongKey123


### PR DESCRIPTION
Implemented JWT authentication support.
Changes made:

- Added `POST /api/auth/login` endpoint
- Created `UserLoginRequestDto` and `UserLoginResponseDto`
- Implemented `AuthenticationService` for user authentication
- Added `JwtUtil` for JWT token generation and validation
- Added `JwtAuthenticationFilter` for processing JWT tokens from Authorization header
- Updated `SecurityConfig`:

- Added JWT filter to Security Filter Chain
- Configured `AuthenticationManager`
- Made `/auth/login` publicly accessible
- Added JWT secret property to application configuration files
- Added validation for login request DTO

Result
Users can authenticate using email and password and receive a JWT token. Protected endpoints can now be accessed using the token in the `Authorization: Bearer <token>` header.
